### PR TITLE
Inaccuracies on Line #124

### DIFF
--- a/2017.03.17-sqlite/notes.txt
+++ b/2017.03.17-sqlite/notes.txt
@@ -121,7 +121,7 @@ es             0x0	0
 fs             0x0	0
 gs             0x0	0
 
-In the case of fprintf(), the stream pointer is stored in RSI, the pointer to the format string is stored in RDI, and the pointer to the string that should be included in the format string (%s) is stored in RDI. As we suspected, the string pointer (pVfs->zName) looked fairly suspicious. Since the value stored in pVfs->zName did not appear to be a valid pointer, we shifted our attention to where pVfs is set. 
+In the case of fprintf(), the stream pointer is stored in RDI, the pointer to the format string is stored in RSI, and the pointer to the string that should be included in the format string (%s) is stored in RDX. As we suspected, the string pointer (pVfs->zName) looked fairly suspicious. Since the value stored in pVfs->zName did not appear to be a valid pointer, we shifted our attention to where pVfs is set. 
 
 When declared, the pointer to pVfs is left uninitialized. Since the pointer is declared as a local variable, its value at the time of its declaration is whatever stale data exists on the top of the current stack. The sqlite3_file_control() function is responsible for initializing the pVfs pointer. However, sqlite3_file_control()  can terminate prior to initializing the pVfs pointer.
 

--- a/2017.03.17-sqlite/notes.txt
+++ b/2017.03.17-sqlite/notes.txt
@@ -100,8 +100,8 @@ rax            0x0	0
 rbx            0x0	0
 rcx            0x7ffffff4	2147483636
 rdx            0x207463656a626f20	2338603393739812640	<— String Pointer
-rsi            0x4bb7e0	4962272					<— Stream Pointer
-rdi            0x7ffff79b1620	140737347524128			<— Format String
+rsi            0x4bb7e0	4962272					<— Format String
+rdi            0x7ffff79b1620	140737347524128			<— Stream Pointer
 rbp            0x7fffffffc8a0	0x7fffffffc8a0
 rsp            0x7fffffffb070	0x7fffffffb070
 r8             0x0	0


### PR DESCRIPTION
Testing revealed some inaccuracies on line #124. Proposed corrections:

rdx            0x207463656a626f20	2338603393739812640	<— String Pointer
rsi            0x4bb7e0				4962272				<— Format String
rdi            0x7ffff79b1620		140737347524128		<— Stream Pointer